### PR TITLE
spinnaker nodelet: add iceoryx publishing support.

### DIFF
--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11;-Wall;-Wextra")
 
@@ -10,9 +10,6 @@ find_package(catkin REQUIRED COMPONENTS
   image_exposure_msgs image_transport nodelet roscpp sensor_msgs
   wfov_camera_msgs
 )
-
-find_package(iceoryx_posh REQUIRED)
-find_package(iceoryx_utils)
 
 generate_dynamic_reconfigure_options(
   cfg/Spinnaker.cfg
@@ -45,6 +42,10 @@ include_directories(SYSTEM
 include_directories(include)
 
 add_library(SpinnakerCameraLib src/SpinnakerCamera.cpp)
+
+# find optional iceoryx libs.
+find_package(iceoryx_posh)
+find_package(iceoryx_utils)
 
 # Include the Spinnaker Libs
 target_link_libraries(SpinnakerCameraLib
@@ -85,8 +86,8 @@ add_dependencies(Diagnostics ${PROJECT_NAME}_gencfg)
 
 add_library(SpinnakerCameraNodelet src/nodelet.cpp)
 target_link_libraries(SpinnakerCameraNodelet Diagnostics SpinnakerCameraLib Camera Gh3 Cm3 ${catkin_LIBRARIES})
-message("iox found? ${iceoryx_posh-FOUND}")
-if(TRUE) #iceoryx_posh-FOUND)
+if(iceoryx_posh_FOUND)
+    message(STATUS "building with iceoryx")
     target_link_libraries(SpinnakerCameraNodelet iceoryx_posh::iceoryx_posh iceoryx_utils::iceoryx_utils)
     target_compile_definitions(SpinnakerCameraNodelet PRIVATE HAVE_ICEORYX)
 endif()

--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   wfov_camera_msgs
 )
 
-find_package(iceoryx_posh)
+find_package(iceoryx_posh REQUIRED)
 find_package(iceoryx_utils)
 
 generate_dynamic_reconfigure_options(
@@ -85,7 +85,8 @@ add_dependencies(Diagnostics ${PROJECT_NAME}_gencfg)
 
 add_library(SpinnakerCameraNodelet src/nodelet.cpp)
 target_link_libraries(SpinnakerCameraNodelet Diagnostics SpinnakerCameraLib Camera Gh3 Cm3 ${catkin_LIBRARIES})
-if(iceoryx_posh-FOUND)
+message("iox found? ${iceoryx_posh-FOUND}")
+if(TRUE) #iceoryx_posh-FOUND)
     target_link_libraries(SpinnakerCameraNodelet iceoryx_posh::iceoryx_posh iceoryx_utils::iceoryx_utils)
     target_compile_definitions(SpinnakerCameraNodelet PRIVATE HAVE_ICEORYX)
 endif()

--- a/spinnaker_camera_driver/CMakeLists.txt
+++ b/spinnaker_camera_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.5)
 
 set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11;-Wall;-Wextra")
 
@@ -10,6 +10,9 @@ find_package(catkin REQUIRED COMPONENTS
   image_exposure_msgs image_transport nodelet roscpp sensor_msgs
   wfov_camera_msgs
 )
+
+find_package(iceoryx_posh)
+find_package(iceoryx_utils)
 
 generate_dynamic_reconfigure_options(
   cfg/Spinnaker.cfg
@@ -82,6 +85,10 @@ add_dependencies(Diagnostics ${PROJECT_NAME}_gencfg)
 
 add_library(SpinnakerCameraNodelet src/nodelet.cpp)
 target_link_libraries(SpinnakerCameraNodelet Diagnostics SpinnakerCameraLib Camera Gh3 Cm3 ${catkin_LIBRARIES})
+if(iceoryx_posh-FOUND)
+    target_link_libraries(SpinnakerCameraNodelet iceoryx_posh::iceoryx_posh iceoryx_utils::iceoryx_utils)
+    target_compile_definitions(SpinnakerCameraNodelet PRIVATE HAVE_ICEORYX)
+endif()
 
 add_executable(spinnaker_camera_node src/node.cpp)
 target_link_libraries(spinnaker_camera_node SpinnakerCameraLib ${catkin_LIBRARIES})

--- a/spinnaker_camera_driver/src/SpinnakerCamera.cpp
+++ b/spinnaker_camera_driver/src/SpinnakerCamera.cpp
@@ -354,9 +354,8 @@ bool SpinnakerCamera::grabImage(sensor_msgs::Image* image, const std::string& fr
       {
         // Set Image Time Stamp. Use -37s to account for UTC/TAI offset.
         ros::Time imgStamp(image_ptr->GetTimeStamp() * 1e-9);
-	    ros::Duration ptpOffset(-37);
+        ros::Duration ptpOffset(-37);
         image->header.stamp = imgStamp + ptpOffset;
-        image->image.header.stamp = imgStamp + ptpOffset;
 
         // Check the bits per pixel.
         size_t bitsPerPixel = image_ptr->GetBitsPerPixel();

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -497,7 +497,7 @@ private:
     if (use_iox_)
     {
       NODELET_DEBUG("instantiating iox publisher");
-      iox_pub_ = IoxPublisher(pnh, "image");
+      iox_pub_ = IoxPublisher(pnh, pub_->getPublisher().getTopic());
     }
     #endif
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -763,6 +763,10 @@ private:
 
       iox_pub_->sendChunk(chunk);
 
+      // once the chunk has been sent, we don't want to free it - that's a job
+      // for the receivers.
+      chunk = nullptr;
+
       return;
     }
     #endif

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -68,6 +68,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <dynamic_reconfigure/server.h>  // Needed for the dynamic_reconfigure gui service to run
 
+#ifdef HAVE_ICEORYX
+#include <iceoryx_posh/popo/publisher.hpp>
+#endif
+
 #include <fstream>
 #include <string>
 

--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -82,6 +82,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace
 {
 
+#ifdef HAVE_ICEORYX
 struct ScopedAction
 {
   using Action = std::function<void(void)>;
@@ -105,10 +106,9 @@ struct ScopedAction
   Action action;
 };
 
-#ifdef HAVE_ICEORYX
-std::unique_ptr<iox::popo::Publisher> instantiateIoxPublisher(const std::string &topic)
+std::unique_ptr<iox::popo::Publisher> instantiateIoxPublisher(const ros::NodeHandle &nh, const std::string &topic)
 {
-  iox::runtime::PoshRuntime::getInstance("/flir_oryx");
+  iox::runtime::PoshRuntime::getInstance(nh.resolveName("/flir_oryx"));
 
   if (topic.size() > 100)
   {
@@ -123,6 +123,75 @@ std::unique_ptr<iox::popo::Publisher> instantiateIoxPublisher(const std::string 
   return std::unique_ptr<iox::popo::Publisher>{
     new iox::popo::Publisher(iox::capro::ServiceDescription{"oryx", "0", topicCStr})};
 }
+
+class IoxPublisher
+{
+public:
+  IoxPublisher() = default;
+
+  IoxPublisher(const ros::NodeHandle &nh, const std::string &topic)
+    : pub(instantiateIoxPublisher(nh, topic))
+  {
+    if (pub)
+      pub->offer();
+  }
+
+  bool hasSubscribers() noexcept
+  {
+    return pub && pub->hasSubscribers();
+  }
+
+  operator bool() const noexcept
+  {
+    return !!pub;
+  }
+
+  void publish(const wfov_camera_msgs::WFOVImage &img)
+  {
+    if (!pub)
+      return;
+
+    iox::mepoo::ChunkHeader *chunk{ };
+    ScopedAction freeChunk([this, &chunk] { if (chunk) pub->freeChunk(chunk); });
+
+    const auto len = ros::serialization::serializationLength(img);
+    ROS_DEBUG("image ser len %u", len);
+
+    chunk = pub->allocateChunkWithHeader(len, UseDynamicSizes);
+    if (!chunk)
+      return;
+
+    ros::serialization::OStream stream(
+      reinterpret_cast<uint8_t *>(chunk->payload()),
+      static_cast<uint32_t>(chunk->m_info.m_payloadSize));
+
+    ros::serialization::serialize(stream, img);
+
+    pub->sendChunk(chunk);
+
+    // once the chunk has been sent, we don't want to free it - that's a job
+    // for the receivers.
+    chunk = nullptr;
+  }
+
+private:
+  enum { UseDynamicSizes = true };
+
+  std::unique_ptr<iox::popo::Publisher> pub{ };
+};
+#else
+class IoxPublisher
+{
+public:
+  IoxPublisher() = default;
+
+  IoxPublisher(const ros::NodeHandle &, const std::string &) { }
+
+  bool hasSubscribers() noexcept { return false; }
+  operator bool() const noexcept { return false; }
+
+  void publish(const cv_bridge::CvImage &) { }
+};
 #endif
 
 }
@@ -418,13 +487,17 @@ private:
             diagnostic_updater::TimeStampStatusParam(min_acceptable,
                                                      max_acceptable)));
 
+    pnh.getParam("wait_for_subscribers", wait_for_subs_);
+    NODELET_DEBUG("wait for subscribers? %s", wait_for_subs_ ? "yes" : "no");
+
     #ifdef HAVE_ICEORYX
-    bool use_iox{false};
-    pnh.param<bool>("use_iceoryx_image_pub", use_iox);
-    if (use_iox)
+    pnh.getParam("use_iceoryx_image_pub", use_iox_);
+    NODELET_DEBUG("(oryx) use iceoryx publisher for wfov? %s", use_iox_ ? "yes" : "no");
+
+    if (use_iox_)
     {
       NODELET_DEBUG("instantiating iox publisher");
-      iox_pub_ = instantiateIoxPublisher("image");
+      iox_pub_ = IoxPublisher(pnh, "image");
     }
     #endif
 
@@ -449,6 +522,8 @@ private:
     {
         diag_man->addDiagnostic<int>("U3VMessageChannelID");
     }
+
+    connectCb();
   }
 
   /**
@@ -508,10 +583,11 @@ private:
       STOPPED,
       DISCONNECTED,
       CONNECTED,
-      STARTED
+      STARTED,
+      WAITING
     };
 
-    State state = DISCONNECTED;
+    State state = WAITING;
     State previous_state = NONE;
 
     while (!boost::this_thread::interruption_requested())  // Block until we need to stop this thread.
@@ -522,6 +598,30 @@ private:
 
       switch (state)
       {
+        case WAITING:
+        {
+          if (!wait_for_subs_)
+          {
+            NODELET_DEBUG("devicePoll: skipping subcriber wait since wait_for_subscribers param is set to false.");
+            state = DISCONNECTED;
+            break;
+          }
+
+          NODELET_DEBUG_ONCE("devicePoll: waiting for subs");
+          const auto pubCount = pub_->getPublisher().getNumSubscribers();
+          const auto itCount = it_pub_.getNumSubscribers();
+
+          if (pubCount + itCount == 0)
+          {
+            ros::Duration(0.1).sleep();
+            break;
+          }
+
+          NODELET_DEBUG("devicePoll: have subs, advancing to next state.");
+          state = DISCONNECTED;
+
+          break;
+        }
         case ERROR:
 // Generally there's no need to stop before disconnecting after an
 // error. Indeed, stop will usually fail.
@@ -689,7 +789,7 @@ private:
             publishImage(*wfov_image);
 
             // Publish the message using standard image transport
-            if (it_pub_.getNumSubscribers() > 0)
+            if (!wait_for_subs_ || it_pub_.getNumSubscribers() > 0)
             {
               sensor_msgs::ImagePtr image(new sensor_msgs::Image(wfov_image->image));
               it_pub_.publish(image, ci_);
@@ -740,36 +840,11 @@ private:
 
   void publishImage(const wfov_camera_msgs::WFOVImage &img)
   {
-    enum { UseDynamicSizes = true };
-
-    #ifdef HAVE_ICEORYX
-    if (iox_pub_)
+    if (iox_pub_.hasSubscribers())
     {
-      iox::mepoo::ChunkHeader *chunk{ };
-      ScopedAction freeChunk([this, &chunk] { if (chunk) iox_pub_->freeChunk(chunk); });
-
-      auto len = ros::serialization::serializationLength(img);
-      NODELET_DEBUG("image ser len: %u", len);
-
-      chunk = iox_pub_->allocateChunkWithHeader(len, UseDynamicSizes);
-      if (!chunk)
-        return;
-
-      ros::serialization::OStream stream(
-        reinterpret_cast<uint8_t *>(chunk->payload()),
-        static_cast<uint32_t>(chunk->m_info.m_payloadSize));
-
-      ros::serialization::serialize(stream, img);
-
-      iox_pub_->sendChunk(chunk);
-
-      // once the chunk has been sent, we don't want to free it - that's a job
-      // for the receivers.
-      chunk = nullptr;
-
+      iox_pub_.publish(img);
       return;
     }
-    #endif
 
     if (pub_)
       pub_->publish(img);
@@ -789,9 +864,7 @@ private:
   std::shared_ptr<diagnostic_updater::DiagnosedPublisher<wfov_camera_msgs::WFOVImage> > pub_;  ///< Diagnosed
   std::shared_ptr<ros::Publisher> diagnostics_pub_;
 
-  #ifdef HAVE_ICEORYX
-  std::unique_ptr<iox::popo::Publisher> iox_pub_;
-  #endif
+  IoxPublisher iox_pub_;
 
   /// publisher, has to be
   /// a pointer because of
@@ -827,7 +900,9 @@ private:
   bool do_rectify_;  ///< Whether or not to rectify as if part of an image.  Set to false if whole image, and true if in
                      /// ROI mode.
 
-  bool enable_ptp_;
+  bool enable_ptp_{ };
+  bool use_iox_{ };
+  bool wait_for_subs_{true};
 
   // For GigE cameras:
   /// If true, GigE packet size is automatically determined, otherwise packet_size_ is used:


### PR DESCRIPTION
add iox publisher support to the camera nodelet.
this also changes connection callback usage to poll for subscriptions to avoid potential race conditions and allow configuration to publish to the debayer nodelet (or elsewhere) unconditionally.