### PR TITLE
nodelet: fix segfault in devicePoll().

### DIFF
--- a/spinnaker_camera_driver/src/nodelet.cpp
+++ b/spinnaker_camera_driver/src/nodelet.cpp
@@ -607,6 +607,12 @@ private:
             break;
           }
 
+          if (!pub_)
+          {
+            NODELET_WARN("devicePoll: publisher instance is null.");
+            break;
+          }
+
           NODELET_DEBUG_ONCE("devicePoll: waiting for subs");
           const auto pubCount = pub_->getPublisher().getNumSubscribers();
           const auto itCount = it_pub_.getNumSubscribers();


### PR DESCRIPTION
device poll can be called prior to pub_ instantiation, since the connection
callback is created prior to the publisher ctor in onInit().

null-check the publisher in the connection callback to avoid triggering
segfaults when the race condition is triggered.

note, this doesn't fix the race condition, since that'd require messing with
the connection callback setup, which is required for creating the publisher,
but we shouldn't need to resolve that in any other way.

this normally happened when starting a bunch of other ros nodes along with the
oryx node.